### PR TITLE
Fully qualify BlockTestCore::execution to avoid confusion with std::execution

### DIFF
--- a/src/actionApplyForce.cpp
+++ b/src/actionApplyForce.cpp
@@ -44,7 +44,7 @@ execution ActionApplyForce::execute(const TestRepetitions& testrepetition)
    if(!ok)
     {
         addProblem(testrepetition,Severity::critical,"Unable to open ports applyforce",true);
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     yarp::os::Network::connect(localExtWrenchPort,remoteExtWrenchPort);
@@ -55,7 +55,7 @@ execution ActionApplyForce::execute(const TestRepetitions& testrepetition)
     if(tokenized.size()!=8)
     {
         addProblem(testrepetition,Severity::error,"Error in parameter number for applyForce",true);
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     yarp::os::Bottle cmd;
@@ -78,6 +78,6 @@ execution ActionApplyForce::execute(const TestRepetitions& testrepetition)
       
     extWrenchPort.interrupt();
     extWrenchPort.close();    
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }
 }

--- a/src/actionCanRead.cpp
+++ b/src/actionCanRead.cpp
@@ -52,7 +52,7 @@ execution ActionCanRead::execute(const TestRepetitions& testrepetition)
     {
         logStream << "Unable to find " << polyDriverTag_ <<" in the depot";
         addProblem(testrepetition, Severity::error, logStream.str(),true);
-        return execution::continueexecution;
+        return BlockTestCore::execution::continueexecution;
     }
     auto pdrPtr = pdr->second;
     
@@ -118,6 +118,6 @@ execution ActionCanRead::execute(const TestRepetitions& testrepetition)
     
     }
 
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }
 }

--- a/src/actionCanWrite.cpp
+++ b/src/actionCanWrite.cpp
@@ -49,7 +49,7 @@ execution ActionCanWrite::execute(const TestRepetitions& testrepetition)
     {
         logStream << "Unable to find " << polyDriverTag_ <<" in the depot";
         addProblem(testrepetition, Severity::error, logStream.str(),true);
-        return execution::continueexecution;
+        return BlockTestCore::execution::continueexecution;
     }
     auto pdrPtr = pdr->second;
    
@@ -108,6 +108,6 @@ execution ActionCanWrite::execute(const TestRepetitions& testrepetition)
             
     }
     
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }
 }

--- a/src/actionCheckComDistance.cpp
+++ b/src/actionCheckComDistance.cpp
@@ -55,7 +55,7 @@ execution ActionCheckComDistance::execute(const TestRepetitions&)
     if(error)
         addProblem(testrepetition,Severity::error);
 */
-    return execution::stopexecution;
+    return BlockTestCore::execution::stopexecution;
 }
 
 }

--- a/src/actionCheckJointPosition.cpp
+++ b/src/actionCheckJointPosition.cpp
@@ -46,14 +46,14 @@ execution ActionCheckJointPosition::execute(const TestRepetitions& testrepetitio
     if(!YarpActionDepotStart::polyDriverDepot_[wrapperPrefix_]->view(iencoders))
     {
         addProblem(testrepetition,Severity::error,"Unable to open encoder control mode interface 2",true);        
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     int nj{0};
     if(!iencoders->getAxes(&nj))
     {
         addProblem(testrepetition,Severity::error,"Unable to open encoder control mode interface 3",true);
-        return execution::stopexecution;;    
+        return BlockTestCore::execution::stopexecution;;    
     }       
          
     std::map<std::string, int> jointNames;
@@ -64,7 +64,7 @@ execution ActionCheckJointPosition::execute(const TestRepetitions& testrepetitio
     {
         TXLOG(Severity::error)<<"Joint not found:"<<jointname_<<std::endl;   
         addProblem(testrepetition,Severity::error,"Joint not found:",false);
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100)); 
@@ -85,7 +85,7 @@ execution ActionCheckJointPosition::execute(const TestRepetitions& testrepetitio
     {
         TXLOG(Severity::debug)<<"Joint position check value ok:"<<ref<<" expected:" <<expectedValue_<<" tolerance:"<<tolerance_ <<" name:"<<jointname_<<std::endl;   
     }
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 
 }

--- a/src/actionCheckPosition.cpp
+++ b/src/actionCheckPosition.cpp
@@ -61,34 +61,34 @@ execution ActionCheckPosition::execute(const TestRepetitions& testrepetition)
         addProblem(testrepetition,Severity::critical,"FBE readings should have 6 elements",false);
         fbePort.interrupt();
         fbePort.close();  
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }   
 
     TXLOG(Severity::debug)<<"FBE x:"<<coordList->get(0).asFloat64()<<" y:"<<coordList->get(1).asFloat64()<<" z:"<<coordList->get(2).asFloat64()<<std::endl;
     
-    execution error=execution::stopexecution;;
+    execution error=BlockTestCore::execution::stopexecution;;
     if(xminposition_&& std::abs(xminposition_)>std::abs(coordList->get(0).asFloat64()))
     {
         TXLOG(Severity::error)<<"FBE x not enough:"<<coordList->get(0).asFloat64()<<" desidered at least:"<<xminposition_<<std::endl;
-        error=execution::continueexecution;;
+        error=BlockTestCore::execution::continueexecution;;
     }
     if(yminposition_ &&  std::abs(yminposition_)>std::abs(coordList->get(1).asFloat64()))
     {
         TXLOG(Severity::error)<<"FBE y not enough:"<<coordList->get(1).asFloat64()<<" desidered at least:"<<yminposition_<<std::endl;
-        error=execution::continueexecution;;        
+        error=BlockTestCore::execution::continueexecution;;        
     }
     if(zminposition_ &&  std::abs(zminposition_)>std::abs(coordList->get(2).asFloat64()))
     {
         TXLOG(Severity::error)<<"FBE z not enough:"<<coordList->get(2).asFloat64()<<" desidered at least:"<<zminposition_<<std::endl;
-        error=execution::continueexecution;;        
+        error=BlockTestCore::execution::continueexecution;;        
     }
 
-    if(error==execution::stopexecution)
+    if(error==BlockTestCore::execution::stopexecution)
         addProblem(testrepetition,Severity::error,"FBE not enough",true);
     
     fbePort.interrupt();
     fbePort.close();  
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 
 }

--- a/src/actionCheckRobot.cpp
+++ b/src/actionCheckRobot.cpp
@@ -48,7 +48,7 @@ execution ActionCheckRobot::execute(const TestRepetitions& testrepetition)
     {
         addProblem(testrepetition,Severity::critical,"getAxes failed",true);
     }        
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 
 }

--- a/src/actionCheckVertical.cpp
+++ b/src/actionCheckVertical.cpp
@@ -43,13 +43,13 @@ execution ActionCheckVertical::execute(const TestRepetitions& testrepetition)
     if(!ok)
     {
         addProblem(testrepetition,Severity::critical,"Unable to open ports checkvertical",true);
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }
     ok=yarp::os::Network::connect(remoteImuPort.c_str(), localImuPort.c_str());
     if(!ok)
     {
         addProblem(testrepetition,Severity::critical,"Unable to connect to imu port",true);
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }
 
     // To check the robot is vertical, we do a simple test: we check if the z component of the
@@ -58,36 +58,36 @@ execution ActionCheckVertical::execute(const TestRepetitions& testrepetition)
     if(!imuReadings)
     {
         addProblem(testrepetition,Severity::critical,"Impossible to read accelerometer measurements",true);
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }
     if(imuReadings->size()<12)
     {
         TXLOG(Severity::critical)<<"IMU readings should have at least 12 elements current:"<<imuReadings->size()<<std::endl;
         addProblem(testrepetition,Severity::critical,"IMU readings should have at least 12 elements",false);
-        return execution::stopexecution;;        
+        return BlockTestCore::execution::stopexecution;;        
     }
 
     double gravityOnX = std::fabs((*imuReadings)[3]);
     double gravityOnY = std::fabs((*imuReadings)[4]);
     double gravityOnZ = std::fabs((*imuReadings)[5]);
 
-    execution error{execution::stopexecution};
+    execution error{BlockTestCore::execution::stopexecution};
     if(!(gravityOnX < gravityOnZ))
     {
         TXLOG(Severity::error)<<"Absolute gravity on x:"<<gravityOnX<< " is greater then on z:"<<gravityOnZ<<std::endl;
-        error=execution::continueexecution;;
+        error=BlockTestCore::execution::continueexecution;;
     }
     if(!(gravityOnY < gravityOnZ))
     {
         TXLOG(Severity::error)<<"Absolute gravity on y:"<<gravityOnY<< " is greater then on z:"<<gravityOnZ<<std::endl;
-        error=execution::continueexecution;
+        error=BlockTestCore::execution::continueexecution;
     }
 
-    if(error==execution::stopexecution)
+    if(error==BlockTestCore::execution::stopexecution)
         addProblem(testrepetition,Severity::error,"Absolute gravity",true);
 
     imuPort.interrupt();
     imuPort.close();
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 }

--- a/src/actionPolydriverClose.cpp
+++ b/src/actionPolydriverClose.cpp
@@ -39,13 +39,13 @@ execution ActionPolydriverClose::execute(const TestRepetitions&)
         TXLOG(Severity::info)<<"Close PolyDrive tag:"<<tag_<<std::endl;
         TestRepetitions rep{0,0};
         addProblem(rep, Severity::critical, "Polydriver failed to close tag:"+tag_,true);
-        return execution::continueexecution;
+        return BlockTestCore::execution::continueexecution;
     }
     
     it->second->close();
     YarpActionDepotStart::polyDriverDepot_.erase(it);
     TXLOG(Severity::info)<<"Close PolyDrive tag:"<<tag_<<std::endl;
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }
 
 

--- a/src/actionPolydriverOpener.cpp
+++ b/src/actionPolydriverOpener.cpp
@@ -46,7 +46,7 @@ execution ActionPolydriverOpener::execute(const TestRepetitions&)
         TestRepetitions rep{0,0};
         addProblem(rep, Severity::critical, "Polydriver failed to open tag:"+tag_,true);
     }
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }
 
 

--- a/src/actionPortClose.cpp
+++ b/src/actionPortClose.cpp
@@ -46,7 +46,7 @@ execution ActionPortClose::execute(const TestRepetitions& testrepetition)
     {
         logStream << "Unable to find " << portname_<<" in the port depot";
         addProblem(testrepetition, Severity::error, logStream.str(),true);
-        return execution::continueexecution;
+        return BlockTestCore::execution::continueexecution;
     }
     auto port_ptr = portIt->second;
 
@@ -64,5 +64,5 @@ execution ActionPortClose::execute(const TestRepetitions& testrepetition)
         addProblem(testrepetition, Severity::error, logStream.str(),true);
     }
 
-	return execution::continueexecution;
+	return BlockTestCore::execution::continueexecution;
 }

--- a/src/actionPortConnect.cpp
+++ b/src/actionPortConnect.cpp
@@ -39,7 +39,7 @@ execution ActionPortConnect::execute(const TestRepetitions& testrepetition)
 		stringstream logStream;
 		logStream << "Port not exists " << src_;
 		addProblem(testrepetition, Severity::error, logStream.str(),true);
-		return execution::continueexecution;
+		return BlockTestCore::execution::continueexecution;
 	}	
 	ok=Network::exists(dst_);
 	if(!ok)
@@ -47,7 +47,7 @@ execution ActionPortConnect::execute(const TestRepetitions& testrepetition)
 		stringstream logStream;
 		logStream << "Port not exists " << dst_;
 		addProblem(testrepetition, Severity::error, logStream.str(),true);
-		return execution::continueexecution;
+		return BlockTestCore::execution::continueexecution;
 	}
 	
 	ok=Network::isValidPortName(src_);
@@ -57,7 +57,7 @@ execution ActionPortConnect::execute(const TestRepetitions& testrepetition)
 		stringstream logStream;
 		logStream << "Port not valid " << src_ << " -> " << dst_ << " with "<<crr_<<" carrier";
 		addProblem(testrepetition, Severity::error, logStream.str(),true);
-		return execution::continueexecution;
+		return BlockTestCore::execution::continueexecution;
 	}
 
 	ok &= Network::connect(src_, dst_, crr_);
@@ -67,5 +67,5 @@ execution ActionPortConnect::execute(const TestRepetitions& testrepetition)
 		logStream << "Unable to connect " << src_ << " -> " << dst_ << " with "<<crr_<<" carrier";
 		addProblem(testrepetition, Severity::error, logStream.str(),true);
 	}
-	return execution::continueexecution;
+	return BlockTestCore::execution::continueexecution;
 }

--- a/src/actionPortDisconnect.cpp
+++ b/src/actionPortDisconnect.cpp
@@ -40,5 +40,5 @@ execution ActionPortDisconnect::execute(const TestRepetitions& testrepetition)
 		logStream << "Unable to disconnect " << src_ << " -> " << dst_ ;
 		addProblem(testrepetition, Severity::critical, logStream.str(),true);
 	}
-	return execution::continueexecution;
+	return BlockTestCore::execution::continueexecution;
 }

--- a/src/actionPortOpen.cpp
+++ b/src/actionPortOpen.cpp
@@ -43,5 +43,5 @@ execution ActionPortOpen::execute(const TestRepetitions& testrepetition)
         addProblem(testrepetition, Severity::error, logStream.str(),true);
     }
 
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }

--- a/src/actionPortRead.cpp
+++ b/src/actionPortRead.cpp
@@ -38,7 +38,7 @@ execution ActionPortRead::execute(const TestRepetitions& testrepetition)
         stringstream logStream;
         logStream << "Unable to find " << portname_;
         addProblem(testrepetition, Severity::error, logStream.str(),true);
-        return execution::continueexecution;   
+        return BlockTestCore::execution::continueexecution;   
     }
 
     auto port=it;
@@ -49,7 +49,7 @@ execution ActionPortRead::execute(const TestRepetitions& testrepetition)
         stringstream logStream;
         logStream << "Unable to read " << portname_;
         addProblem(testrepetition, Severity::error, logStream.str(),true);
-        return execution::continueexecution;          
+        return BlockTestCore::execution::continueexecution;          
     }
 
     if(input.toString()!=value_)
@@ -57,8 +57,8 @@ execution ActionPortRead::execute(const TestRepetitions& testrepetition)
         stringstream logStream;
         logStream << "Read unexpected value " << portname_;
         addProblem(testrepetition, Severity::error, logStream.str(),true);
-        return execution::continueexecution;                  
+        return BlockTestCore::execution::continueexecution;                  
     }
 
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }

--- a/src/actionPortWrite.cpp
+++ b/src/actionPortWrite.cpp
@@ -38,7 +38,7 @@ execution ActionPortWrite::execute(const TestRepetitions& testrepetition)
         stringstream logStream;
         logStream << "Unable to find " << portname_;
         addProblem(testrepetition, Severity::error, logStream.str(),true);
-        return execution::continueexecution;   
+        return BlockTestCore::execution::continueexecution;   
     }
 
     auto port=it;
@@ -49,8 +49,8 @@ execution ActionPortWrite::execute(const TestRepetitions& testrepetition)
         stringstream logStream;
         logStream << "Unable to write " << portname_;
         addProblem(testrepetition, Severity::error, logStream.str(),true);
-        return execution::continueexecution;          
+        return BlockTestCore::execution::continueexecution;          
     }
 
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }

--- a/src/actionReset.cpp
+++ b/src/actionReset.cpp
@@ -56,7 +56,7 @@ execution ActionReset::execute(const TestRepetitions& testrepetition)
     yarp::os::SystemClock systemClock;
     systemClock.delay(1.0);
     clockClientPort.close();
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 
 }

--- a/src/actionResetPose.cpp
+++ b/src/actionResetPose.cpp
@@ -56,7 +56,7 @@ execution ActionResetPose::execute(const TestRepetitions& testrepetition)
     yarp::os::SystemClock systemClock;
     systemClock.delay(1.0);
     clockClientPort.close();
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 
 }

--- a/src/actionSendDirectPosition.cpp
+++ b/src/actionSendDirectPosition.cpp
@@ -58,7 +58,7 @@ execution ActionSendDirectPosition::execute(const TestRepetitions& testrepetitio
 
     if(degree_.empty()) {
         addProblem(testrepetition,Severity::error,"Missing degree information",true);
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
 
@@ -69,7 +69,7 @@ execution ActionSendDirectPosition::execute(const TestRepetitions& testrepetitio
     if(degree_.size()!=jointToMove_.size())
     {
         addProblem(testrepetition,Severity::error,"Joint info not cooerent",true);
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     yarp::dev::IPositionDirect *ipos=nullptr;
@@ -78,19 +78,19 @@ execution ActionSendDirectPosition::execute(const TestRepetitions& testrepetitio
     if(YarpActionDepotStart::polyDriverDepot_.find(wrapperPrefix_)==YarpActionDepotStart::polyDriverDepot_.end())
     {
         addProblem(testrepetition,Severity::error,"Unable to find Polydrive:"+wrapperPrefix_,true);
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     if(!YarpActionDepotStart::polyDriverDepot_[wrapperPrefix_]->view(ipos))
     {
         addProblem(testrepetition,Severity::error,"Unable to open pos mode interface",true);
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     if(!YarpActionDepotStart::polyDriverDepot_[wrapperPrefix_]->view(icmd))
     {
         addProblem(testrepetition,Severity::error,"Unable to open control mode interface",true);      
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     std::map<std::string,int> jointNames;
@@ -105,7 +105,7 @@ execution ActionSendDirectPosition::execute(const TestRepetitions& testrepetitio
         {
             TXLOG(Severity::error)<<"Error joint not found:"<<jointToMove_[index]<<std::endl;
             addProblem(testrepetition,Severity::critical,"Error joint not found",false);
-            return execution::stopexecution;
+            return BlockTestCore::execution::stopexecution;
         }
         
         desiredJoint.push_back(it->second);
@@ -114,7 +114,7 @@ execution ActionSendDirectPosition::execute(const TestRepetitions& testrepetitio
         if (std::isnan(currentDegree))
         {
             TXLOG(Severity::error)<<"Empty number from table"<<std::endl;
-            return execution::continueexecution;
+            return BlockTestCore::execution::continueexecution;
         }
 
         desiredJointPosInDegrees.push_back(currentDegree);
@@ -125,7 +125,7 @@ execution ActionSendDirectPosition::execute(const TestRepetitions& testrepetitio
     ipos->setPositions(jointToMove_.size(),desiredJoint.data(),desiredJointPosInDegrees.data());
     //TXLOG(Severity::debug)<<"---------:"<<desiredJointPosInDegrees[0]<<std::endl;
 
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }
 
 }

--- a/src/actionSendPosition.cpp
+++ b/src/actionSendPosition.cpp
@@ -58,13 +58,13 @@ execution ActionSendPosition::execute(const TestRepetitions& testrepetition)
     if(degree_.size()!=velocity_.size())
     {
         addProblem(testrepetition,Severity::error,"Joint info not cooerent",true);
-        return execution::stopexecution;;      
+        return BlockTestCore::execution::stopexecution;;      
     }
 
     if(degree_.size()!=jointToMove_.size())
     {
         addProblem(testrepetition,Severity::error,"Joint info not cooerent",true);
-        return execution::stopexecution;;      
+        return BlockTestCore::execution::stopexecution;;      
     }
 
     yarp::dev::IPositionControl *ipos{nullptr};
@@ -73,20 +73,20 @@ execution ActionSendPosition::execute(const TestRepetitions& testrepetition)
     if(YarpActionDepotStart::polyDriverDepot_.find(wrapperPrefix_)==YarpActionDepotStart::polyDriverDepot_.end())
     {
         addProblem(testrepetition,Severity::error,"Unable to find Polydrive:"+wrapperPrefix_,true);
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     bool ok=YarpActionDepotStart::polyDriverDepot_[wrapperPrefix_]->view(ipos);
     if(!ok)
     {
         addProblem(testrepetition,Severity::error,"Unable to open pos mode interface",true);
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }
     ok=YarpActionDepotStart::polyDriverDepot_[wrapperPrefix_]->view(icmd);
     if(!ok)
     {
         addProblem(testrepetition,Severity::error,"Unable to open control mode interface",true);
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }
  
     std::map<std::string,int> jointNames;
@@ -101,7 +101,7 @@ execution ActionSendPosition::execute(const TestRepetitions& testrepetition)
         {
             TXLOG(Severity::error)<<"Error joint not found:"<<jointToMove_[index]<<std::endl;
             addProblem(testrepetition,Severity::error,"Error joint not found",false);
-            return execution::stopexecution;;
+            return BlockTestCore::execution::stopexecution;;
         }
         desiredJoint.push_back(it->second);
         desiredJointPosInDegrees.push_back(degree_[index]);
@@ -110,7 +110,7 @@ execution ActionSendPosition::execute(const TestRepetitions& testrepetition)
     }
 
     ipos->positionMove(jointToMove_.size(),desiredJoint.data(),desiredJointPosInDegrees.data());
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 
 }

--- a/src/actionSendPwm.cpp
+++ b/src/actionSendPwm.cpp
@@ -50,7 +50,7 @@ execution ActionSendPwm::execute(const TestRepetitions& testrepetition)
     if(YarpActionDepotStart::polyDriverDepot_.find(wrapperPrefix_)==YarpActionDepotStart::polyDriverDepot_.end())
     {
         addProblem(testrepetition,Severity::error,"Unable to find Polydrive:"+wrapperPrefix_,true);
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     yarp::dev::IPWMControl *ipwm=nullptr;
@@ -73,7 +73,7 @@ execution ActionSendPwm::execute(const TestRepetitions& testrepetition)
     {
         TXLOG(Severity::error)<<"Error joint not found:"<<jointname_<<std::endl;
         addProblem(testrepetition,Severity::critical,"Error joint not found",false);
-        return  execution::stopexecution;
+        return  BlockTestCore::execution::stopexecution;
     }
 
     icmd->setControlMode(it->second, VOCAB_CM_PWM);
@@ -134,7 +134,7 @@ execution ActionSendPwm::execute(const TestRepetitions& testrepetition)
 
     ipwm->setRefDutyCycle(it->second, 0);
     yarp::os::Time::delay(time_);
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }
 
 int ActionSendPwm::sign(double value)

--- a/src/actionSendPwmTrain.cpp
+++ b/src/actionSendPwmTrain.cpp
@@ -57,7 +57,7 @@ execution ActionSendPwmTrain::execute(const TestRepetitions& testrepetition)
     if(YarpActionDepotStart::polyDriverDepot_.find(wrapperPrefix_)==YarpActionDepotStart::polyDriverDepot_.end())
     {
         addProblem(testrepetition,Severity::error,"Unable to find Polydrive:"+wrapperPrefix_,true);
-        return execution::stopexecution;
+        return BlockTestCore::execution::stopexecution;
     }
 
     if(!YarpActionDepotStart::polyDriverDepot_[wrapperPrefix_]->view(ipwm))
@@ -73,13 +73,13 @@ execution ActionSendPwmTrain::execute(const TestRepetitions& testrepetition)
     if(!YarpActionDepotStart::polyDriverDepot_[wrapperPrefix_]->view(iencs))
     {
         addProblem(testrepetition,Severity::error,"Unable to view IEncoder interface",true);
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }
 
     if(!iencs->getAxes(&nj))
     {
         addProblem(testrepetition,Severity::error,"getAxes failed",true);
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }    
 
     std::map<std::string,int> jointNames;
@@ -89,7 +89,7 @@ execution ActionSendPwmTrain::execute(const TestRepetitions& testrepetition)
     {
         TXLOG(Severity::error)<<"Error joint not found:"<<jointname_<<std::endl;
         addProblem(testrepetition,Severity::critical,"Error joint not found",false);
-        return execution::stopexecution;;
+        return BlockTestCore::execution::stopexecution;;
     }
     
 
@@ -126,7 +126,7 @@ execution ActionSendPwmTrain::execute(const TestRepetitions& testrepetition)
     }
 
     ipwm->setRefDutyCycle(it->second, 0);
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 
 

--- a/src/actionYarpNow.cpp
+++ b/src/actionYarpNow.cpp
@@ -27,7 +27,7 @@ void ActionYarpNow::beforeExecute()
 
 execution ActionYarpNow::execute(const TestRepetitions&)
 {
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 
 double ActionYarpNow::getDouble()

--- a/src/actionYarpWait.cpp
+++ b/src/actionYarpWait.cpp
@@ -32,7 +32,7 @@ execution ActionYarpWait::execute(const TestRepetitions&)
     //yarp::os::yarpClockType clockType=yarp::os::Time::getClockType();
     //TXLOG(Severity::debug)<<"Using clock type config:"<<yarp::os::Time::clockTypeToString(clockType)<<" Wait value:"<<seconds_<<std::endl;
     yarp::os::Time::delay(seconds_);
-    return execution::continueexecution;
+    return BlockTestCore::execution::continueexecution;
 }
 
 } // namespace YarpActions

--- a/src/unusedactions/actionGenerateTrajectory.cpp
+++ b/src/unusedactions/actionGenerateTrajectory.cpp
@@ -45,6 +45,6 @@ execution ActionGenerateTrajectory::execute(const TestRepetitions& testrepetitio
     }
 
     closeWalking(rpcPortWalking);
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 }

--- a/src/unusedactions/actionPrepareStraightWalking.cpp
+++ b/src/unusedactions/actionPrepareStraightWalking.cpp
@@ -38,5 +38,5 @@ execution ActionPrepareStraightWalking::execute(const TestRepetitions& testrepet
     }
     closeWalking(rpcPortWalking);
     TXLOG(Severity::info)<<"Prepare straight walking OK"<<std::endl;
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }

--- a/src/unusedactions/actionResetWalking.cpp
+++ b/src/unusedactions/actionResetWalking.cpp
@@ -45,7 +45,7 @@ execution ActionResetWalking::execute(const TestRepetitions& testrepetition)
     }    
 
     closeWalking(rpcPortWalking);       
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 
 }

--- a/src/unusedactions/actionSetVelocity.cpp
+++ b/src/unusedactions/actionSetVelocity.cpp
@@ -45,6 +45,6 @@ execution ActionSetVelocity::execute(const TestRepetitions& testrepetition)
     }
 
     closeWalking(rpcPortWalking);    
-    return execution::continueexecution;;
+    return BlockTestCore::execution::continueexecution;;
 }
 }


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1646 .

This is a good example on why it is important not too use to much statements such as `using namespace std`. In blocktest, `BlockTestCore::execution` is defined, while since C++17 in the STL `std::execution` is defined. 

The problem is hidden until someone includes (even transitively, that I guess it is why at the moment we have this feature only on a specific macos image) the `<algorithm>` headers that defines `std::execution`, and then you get errors like:

~~~
2024-05-09T02:39:26.7202600Z [5/31] Building CXX object CMakeFiles/blocktestyarpplugins.dir/src/actionCanWrite.cpp.o
2024-05-09T02:39:26.8205630Z FAILED: CMakeFiles/blocktestyarpplugins.dir/src/actionCanWrite.cpp.o 
2024-05-09T02:39:26.9219240Z /Users/runner/miniconda3/envs/test/bin/x86_64-apple-darwin13.4.0-clang++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -Dblocktestyarpplugins_EXPORTS -I/Users/runner/work/robotology-superbuild/robotology-superbuild/b/src/blocktest-yarp-plugins -I/Users/runner/work/robotology-superbuild/robotology-superbuild/src/blocktest-yarp-plugins/src -I/Users/runner/work/robotology-superbuild/robotology-superbuild/b/src/blocktest-yarp-plugins/thrift -isystem /Users/runner/work/robotology-superbuild/robotology-superbuild/b/install/include/blocktestcore -isystem /Users/runner/work/robotology-superbuild/robotology-superbuild/b/install/include -march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0 -isystem /Users/runner/miniconda3/envs/test/include -Wall -Wextra -O3 -DNDEBUG -std=gnu++17 -isysroot /Applications/Xcode_14.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -fPIC -MD -MT CMakeFiles/blocktestyarpplugins.dir/src/actionCanWrite.cpp.o -MF CMakeFiles/blocktestyarpplugins.dir/src/actionCanWrite.cpp.o.d -o CMakeFiles/blocktestyarpplugins.dir/src/actionCanWrite.cpp.o -c /Users/runner/work/robotology-superbuild/robotology-superbuild/src/blocktest-yarp-plugins/src/actionCanWrite.cpp
2024-05-09T02:39:27.0209090Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/blocktest-yarp-plugins/src/actionCanWrite.cpp:40:1: error: reference to 'execution' is ambiguous
2024-05-09T02:39:27.1209330Z execution ActionCanWrite::execute(const TestRepetitions& testrepetition)
2024-05-09T02:39:27.2210170Z ^
2024-05-09T02:39:27.3212920Z /Users/runner/work/robotology-superbuild/robotology-superbuild/b/install/include/blocktestcore/type.h:65:12: note: candidate found by name lookup is 'BlockTestCore::execution'
2024-05-09T02:39:27.4212430Z enum class execution
2024-05-09T02:39:27.5213500Z            ^
2024-05-09T02:39:27.6216620Z /Users/runner/miniconda3/envs/test/bin/../include/c++/v1/__type_traits/is_execution_policy.h:39:11: note: candidate found by name lookup is 'std::execution'
2024-05-09T02:39:27.7216070Z namespace execution {
2024-05-09T02:39:27.8217460Z           ^
2024-05-09T02:39:27.9220900Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/blocktest-yarp-plugins/src/actionCanWrite.cpp:52:16: error: reference to 'execution' is ambiguous
2024-05-09T02:39:28.0220540Z         return execution::continueexecution;
2024-05-09T02:39:28.1221880Z                ^
2024-05-09T02:39:28.2224610Z /Users/runner/work/robotology-superbuild/robotology-superbuild/b/install/include/blocktestcore/type.h:65:12: note: candidate found by name lookup is 'BlockTestCore::execution'
2024-05-09T02:39:28.3224220Z enum class execution
2024-05-09T02:39:28.4225190Z            ^
2024-05-09T02:39:28.5227630Z /Users/runner/miniconda3/envs/test/bin/../include/c++/v1/__type_traits/is_execution_policy.h:39:11: note: candidate found by name lookup is 'std::execution'
2024-05-09T02:39:28.6226860Z namespace execution {
2024-05-09T02:39:28.7227830Z           ^
2024-05-09T02:39:28.8230120Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/blocktest-yarp-plugins/src/actionCanWrite.cpp:111:12: error: reference to 'execution' is ambiguous
2024-05-09T02:39:28.9230430Z     return execution::continueexecution;
2024-05-09T02:39:29.0231810Z            ^
2024-05-09T02:39:29.1236500Z /Users/runner/work/robotology-superbuild/robotology-superbuild/b/install/include/blocktestcore/type.h:65:12: note: candidate found by name lookup is 'BlockTestCore::execution'
2024-05-09T02:39:29.2239410Z enum class execution
2024-05-09T02:39:29.3240670Z            ^
2024-05-09T02:39:29.4243270Z /Users/runner/miniconda3/envs/test/bin/../include/c++/v1/__type_traits/is_execution_policy.h:39:11: note: candidate found by name lookup is 'std::execution'
2024-05-09T02:39:29.5242920Z namespace execution {
2024-05-09T02:39:29.6252030Z           ^
2024-05-09T02:39:29.7253920Z 3 errors generated.
~~~

A more complete cleanup would be to try to avoid `using namespace std`, but at first I got a simple fix to the CI happy again.