### PR TITLE
Fully qualify BlockTestCore::execution to avoid confusion with std::execution (part 2)

### DIFF
--- a/src/actionApplyForce.cpp
+++ b/src/actionApplyForce.cpp
@@ -35,7 +35,7 @@ void ActionApplyForce::beforeExecute()
     getCommandAttribute("force",force_);    
 }
 
-execution ActionApplyForce::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionApplyForce::execute(const TestRepetitions& testrepetition)
 {
     std::string localExtWrenchPort = "/myPortForExternalWrench:o";
     std::string remoteExtWrenchPort = "/icab/applyExternalWrench/rpc:i";

--- a/src/actionApplyForce.h
+++ b/src/actionApplyForce.h
@@ -25,7 +25,7 @@ class ActionApplyForce : public ActionYarp
 {
     public:
         ActionApplyForce(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;        
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;        
         void beforeExecute() override;
 
     private:

--- a/src/actionCanRead.cpp
+++ b/src/actionCanRead.cpp
@@ -38,7 +38,7 @@ void ActionCanRead::beforeExecute()
 }
 
 
-execution ActionCanRead::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionCanRead::execute(const TestRepetitions& testrepetition)
 {
     unsigned int readMessages=0;
     int timer=0;

--- a/src/actionCanRead.h
+++ b/src/actionCanRead.h
@@ -26,7 +26,7 @@ class ActionCanRead : public ActionYarp
   
 public:
     ActionCanRead(const CommandAttributes& commandAttributes, const std::string& testCode);
-    execution execute(const TestRepetitions& testrepetition) override;
+    BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
     void beforeExecute() override;
 
 protected:

--- a/src/actionCanWrite.cpp
+++ b/src/actionCanWrite.cpp
@@ -37,7 +37,7 @@ void ActionCanWrite::beforeExecute()
     getCommandAttribute("data", data_);   
 }
 
-execution ActionCanWrite::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionCanWrite::execute(const TestRepetitions& testrepetition)
 {
     auto exists {true};
     stringstream logStream;

--- a/src/actionCanWrite.h
+++ b/src/actionCanWrite.h
@@ -27,7 +27,7 @@ class ActionCanWrite : public ActionYarp
 
 public:
     ActionCanWrite(const CommandAttributes& commandAttributes, const std::string& testCode);
-    execution execute(const TestRepetitions& testrepetition) override;
+    BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
     void beforeExecute() override;
 
 protected:

--- a/src/actionCheckComDistance.cpp
+++ b/src/actionCheckComDistance.cpp
@@ -36,7 +36,7 @@ void ActionCheckComDistance::beforeExecute()
 }
 
 
-execution ActionCheckComDistance::execute(const TestRepetitions&)
+BlockTestCore::execution ActionCheckComDistance::execute(const TestRepetitions&)
 {
    /* bool error{false};
     if(test_->comDistance_<commindistance_)

--- a/src/actionCheckComDistance.h
+++ b/src/actionCheckComDistance.h
@@ -22,7 +22,7 @@ class ActionCheckComDistance : public ActionYarp
 {
     public:
         ActionCheckComDistance(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;
     
     private:

--- a/src/actionCheckJointPosition.cpp
+++ b/src/actionCheckJointPosition.cpp
@@ -39,7 +39,7 @@ void ActionCheckJointPosition::beforeExecute()
     getCommandAttribute("tolerance",tolerance_);    
 }
 
-execution ActionCheckJointPosition::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionCheckJointPosition::execute(const TestRepetitions& testrepetition)
 {
     yarp::dev::IEncoders *iencoders=nullptr;
     

--- a/src/actionCheckJointPosition.h
+++ b/src/actionCheckJointPosition.h
@@ -25,7 +25,7 @@ class ActionCheckJointPosition : public ActionYarp
 {
     public:
         ActionCheckJointPosition(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
     
     private:

--- a/src/actionCheckPosition.cpp
+++ b/src/actionCheckPosition.cpp
@@ -36,7 +36,7 @@ void ActionCheckPosition::beforeExecute()
 }
 
 
-execution ActionCheckPosition::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionCheckPosition::execute(const TestRepetitions& testrepetition)
 {
     yarp::os::Port fbePort;
     std::string localfbePort  = "/myrobot/odometry:i";
@@ -66,7 +66,7 @@ execution ActionCheckPosition::execute(const TestRepetitions& testrepetition)
 
     TXLOG(Severity::debug)<<"FBE x:"<<coordList->get(0).asFloat64()<<" y:"<<coordList->get(1).asFloat64()<<" z:"<<coordList->get(2).asFloat64()<<std::endl;
     
-    execution error=BlockTestCore::execution::stopexecution;;
+    BlockTestCore::execution error=BlockTestCore::execution::stopexecution;;
     if(xminposition_&& std::abs(xminposition_)>std::abs(coordList->get(0).asFloat64()))
     {
         TXLOG(Severity::error)<<"FBE x not enough:"<<coordList->get(0).asFloat64()<<" desidered at least:"<<xminposition_<<std::endl;

--- a/src/actionCheckPosition.h
+++ b/src/actionCheckPosition.h
@@ -21,7 +21,7 @@ class ActionCheckPosition : public ActionYarp
 {
     public:
         ActionCheckPosition(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
     
     private:

--- a/src/actionCheckRobot.cpp
+++ b/src/actionCheckRobot.cpp
@@ -35,7 +35,7 @@ void ActionCheckRobot::beforeExecute()
     getCommandAttribute("wrappername",wrapperPrefix_);  
 }
 
-execution ActionCheckRobot::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionCheckRobot::execute(const TestRepetitions& testrepetition)
 {
     yarp::dev::IEncoders       *iencs;
     int nj;

--- a/src/actionCheckRobot.h
+++ b/src/actionCheckRobot.h
@@ -21,7 +21,7 @@ class ActionCheckRobot : public ActionYarp
 {
     public:
         ActionCheckRobot(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
 
     private:

--- a/src/actionCheckVertical.cpp
+++ b/src/actionCheckVertical.cpp
@@ -34,7 +34,7 @@ void ActionCheckVertical::beforeExecute()
 {
 }
 
-execution ActionCheckVertical::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionCheckVertical::execute(const TestRepetitions& testrepetition)
 {
     yarp::os::BufferedPort<yarp::sig::Vector> imuPort;
     std::string localImuPort  = "/myrobot/imu:i";
@@ -71,7 +71,7 @@ execution ActionCheckVertical::execute(const TestRepetitions& testrepetition)
     double gravityOnY = std::fabs((*imuReadings)[4]);
     double gravityOnZ = std::fabs((*imuReadings)[5]);
 
-    execution error{BlockTestCore::execution::stopexecution};
+    BlockTestCore::execution error{BlockTestCore::execution::stopexecution};
     if(!(gravityOnX < gravityOnZ))
     {
         TXLOG(Severity::error)<<"Absolute gravity on x:"<<gravityOnX<< " is greater then on z:"<<gravityOnZ<<std::endl;

--- a/src/actionCheckVertical.h
+++ b/src/actionCheckVertical.h
@@ -25,7 +25,7 @@ class ActionCheckVertical : public ActionYarp
 {
     public:
         ActionCheckVertical(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
 
     ACTIONREGISTER_DEC_TYPE(ActionCheckVertical)        

--- a/src/actionPolydriverClose.cpp
+++ b/src/actionPolydriverClose.cpp
@@ -30,7 +30,7 @@ ActionPolydriverClose::ActionPolydriverClose(const CommandAttributes& parameters
     tag_ = parameters.at(yarpsyntax::wrappername);
 };
 
-execution ActionPolydriverClose::execute(const TestRepetitions&)
+BlockTestCore::execution ActionPolydriverClose::execute(const TestRepetitions&)
 {
 
     auto it=YarpActionDepotStart::polyDriverDepot_.find(tag_);

--- a/src/actionPolydriverClose.h
+++ b/src/actionPolydriverClose.h
@@ -21,7 +21,7 @@ class ActionPolydriverClose : public YarpActions::ActionYarp {
 public:
   ActionPolydriverClose(const CommandAttributes &parameters,
                          const std::string &testCode);
-  execution execute(const TestRepetitions &) override;
+  BlockTestCore::execution execute(const TestRepetitions &) override;
   void beforeExecute() override{};
 
 private:

--- a/src/actionPolydriverOpener.cpp
+++ b/src/actionPolydriverOpener.cpp
@@ -32,7 +32,7 @@ ActionPolydriverOpener::ActionPolydriverOpener(const CommandAttributes& paramete
     property_.fromString( parameters.at(yarpsyntax::property));
 };
 
-execution ActionPolydriverOpener::execute(const TestRepetitions&)
+BlockTestCore::execution ActionPolydriverOpener::execute(const TestRepetitions&)
 {
     auto pdr = std::make_shared<PolyDriver>();
     bool opened = pdr->open(property_);

--- a/src/actionPolydriverOpener.h
+++ b/src/actionPolydriverOpener.h
@@ -22,7 +22,7 @@ class ActionPolydriverOpener : public YarpActions::ActionYarp {
 public:
   ActionPolydriverOpener(const CommandAttributes &parameters,
                          const std::string &testCode);
-  execution execute(const TestRepetitions &) override;
+  BlockTestCore::execution execute(const TestRepetitions &) override;
   void beforeExecute() override{};
 
 private:

--- a/src/actionPortClose.cpp
+++ b/src/actionPortClose.cpp
@@ -35,7 +35,7 @@ void ActionPortClose::beforeExecute()
 	getCommandAttribute("portname",   portname_);    
 }
 
-execution ActionPortClose::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionPortClose::execute(const TestRepetitions& testrepetition)
 {
     auto exists {true};
     stringstream logStream;

--- a/src/actionPortClose.h
+++ b/src/actionPortClose.h
@@ -26,7 +26,7 @@ class ActionPortClose: public ActionYarp
 {
 public:
     ActionPortClose(const CommandAttributes& commandAttributes, const std::string& testCode);
-    execution execute(const TestRepetitions& testrepetition) override;
+    BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
     void beforeExecute() override;  
 
 protected:

--- a/src/actionPortConnect.cpp
+++ b/src/actionPortConnect.cpp
@@ -30,7 +30,7 @@ void ActionPortConnect::beforeExecute()
 	getCommandAttribute("carrier", crr_);	
 }
 
-execution ActionPortConnect::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionPortConnect::execute(const TestRepetitions& testrepetition)
 {
 	bool ok{ true };
 	ok=Network::exists(src_);

--- a/src/actionPortConnect.h
+++ b/src/actionPortConnect.h
@@ -26,7 +26,7 @@ class ActionPortConnect : public ActionPortDisconnect
 {
 public:
 	ActionPortConnect(const CommandAttributes& commandAttributes, const std::string& testCode);
-	execution execute(const TestRepetitions& testrepetition) override;
+	BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
   void beforeExecute() override;  
 
 private:

--- a/src/actionPortDisconnect.cpp
+++ b/src/actionPortDisconnect.cpp
@@ -30,7 +30,7 @@ void ActionPortDisconnect::beforeExecute()
 	getCommandAttribute("destination", dst_);	
 }
 
-execution ActionPortDisconnect::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionPortDisconnect::execute(const TestRepetitions& testrepetition)
 {
 	auto ok{ true };
 	ok &= Network::disconnect(src_, dst_);

--- a/src/actionPortDisconnect.h
+++ b/src/actionPortDisconnect.h
@@ -26,7 +26,7 @@ class ActionPortDisconnect: public ActionYarp
 {
 public:
 	ActionPortDisconnect(const CommandAttributes& commandAttributes, const std::string& testCode);
-	execution execute(const TestRepetitions& testrepetition) override;
+	BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
     void beforeExecute() override;	
 
 protected:

--- a/src/actionPortOpen.cpp
+++ b/src/actionPortOpen.cpp
@@ -29,7 +29,7 @@ void ActionPortOpen::beforeExecute()
     ActionPortClose::beforeExecute();
 }
 
-execution ActionPortOpen::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionPortOpen::execute(const TestRepetitions& testrepetition)
 {
     auto port = std::make_shared<Port>();
     bool opened_ = port->open(portname_);

--- a/src/actionPortOpen.h
+++ b/src/actionPortOpen.h
@@ -26,7 +26,7 @@ class ActionPortOpen : public ActionPortClose
 {
 public:
     ActionPortOpen(const CommandAttributes& commandAttributes, const std::string& testCode);
-    execution execute(const TestRepetitions& testrepetition) override;
+    BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
     void beforeExecute() override;
 
 	ACTIONREGISTER_DEC_TYPE(ActionPortOpen)

--- a/src/actionPortRead.cpp
+++ b/src/actionPortRead.cpp
@@ -29,7 +29,7 @@ void ActionPortRead::beforeExecute()
     getCommandAttribute("value",   value_);
 }
 
-execution ActionPortRead::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionPortRead::execute(const TestRepetitions& testrepetition)
 {
 
     auto it=YarpActionDepotStart::portDepot_.find(portname_);

--- a/src/actionPortRead.h
+++ b/src/actionPortRead.h
@@ -25,7 +25,7 @@ class ActionPortRead : public ActionYarp
 {
 public:
     ActionPortRead(const CommandAttributes& commandAttributes, const std::string& testCode);
-    execution execute(const TestRepetitions& testrepetition) override;
+    BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
     void beforeExecute() override;
 
 protected:

--- a/src/actionPortWrite.cpp
+++ b/src/actionPortWrite.cpp
@@ -29,7 +29,7 @@ void ActionPortWrite::beforeExecute()
     getCommandAttribute("value",   value_);
 }
 
-execution ActionPortWrite::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionPortWrite::execute(const TestRepetitions& testrepetition)
 {
 
     auto it=YarpActionDepotStart::portDepot_.find(portname_);

--- a/src/actionPortWrite.h
+++ b/src/actionPortWrite.h
@@ -25,7 +25,7 @@ class ActionPortWrite : public ActionYarp
 {
 public:
     ActionPortWrite(const CommandAttributes& commandAttributes, const std::string& testCode);
-    execution execute(const TestRepetitions& testrepetition) override;
+    BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
     void beforeExecute() override;
 
 protected:

--- a/src/actionReset.cpp
+++ b/src/actionReset.cpp
@@ -33,7 +33,7 @@ void ActionReset::beforeExecute()
 {
 }
 
-execution ActionReset::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionReset::execute(const TestRepetitions& testrepetition)
 {
     GazeboYarpPlugins::ClockServer clockServer;
     yarp::os::Port clockClientPort;

--- a/src/actionReset.h
+++ b/src/actionReset.h
@@ -26,7 +26,7 @@ class ActionReset : public ActionYarp
 {
     public:
         ActionReset(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
 
     ACTIONREGISTER_DEC_TYPE(ActionReset)        

--- a/src/actionResetPose.cpp
+++ b/src/actionResetPose.cpp
@@ -33,7 +33,7 @@ void ActionResetPose::beforeExecute()
 {
 }
 
-execution ActionResetPose::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionResetPose::execute(const TestRepetitions& testrepetition)
 {
     GazeboYarpPlugins::ClockServer clockServer;
     yarp::os::Port clockClientPort;

--- a/src/actionResetPose.h
+++ b/src/actionResetPose.h
@@ -26,7 +26,7 @@ class ActionResetPose : public ActionYarp
 {
     public:
         ActionResetPose(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
 
     ACTIONREGISTER_DEC_TYPE(ActionResetPose)        

--- a/src/actionSendDirectPosition.cpp
+++ b/src/actionSendDirectPosition.cpp
@@ -49,7 +49,7 @@ void ActionSendDirectPosition::beforeExecute()
     getCommandAttribute(yarpsyntax::wrappername,wrapperPrefix_);
 }
 
-execution ActionSendDirectPosition::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionSendDirectPosition::execute(const TestRepetitions& testrepetition)
 {
     //TO REMOVE
 

--- a/src/actionSendDirectPosition.h
+++ b/src/actionSendDirectPosition.h
@@ -21,7 +21,7 @@ class ActionSendDirectPosition : public ActionYarp
 {
     public:
         ActionSendDirectPosition(const CommandAttributes& commandAttributes,const std::string& testCode);    
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;
     
     private:

--- a/src/actionSendPosition.cpp
+++ b/src/actionSendPosition.cpp
@@ -44,7 +44,7 @@ void ActionSendPosition::beforeExecute()
     getCommandAttribute("wrappername",wrapperPrefix_);    
 }
 
-execution ActionSendPosition::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionSendPosition::execute(const TestRepetitions& testrepetition)
 {
     //TO REMOVE
     std::ofstream out;

--- a/src/actionSendPosition.h
+++ b/src/actionSendPosition.h
@@ -32,7 +32,7 @@ class ActionSendPosition : public ActionYarp
 {
     public:
         ActionSendPosition(const CommandAttributes& commandAttributes,const std::string& testCode);    
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;
 
     private:

--- a/src/actionSendPwm.cpp
+++ b/src/actionSendPwm.cpp
@@ -40,7 +40,7 @@ void ActionSendPwm::beforeExecute()
     getCommandAttribute("wrappername",wrapperPrefix_);    
 }
 
-execution ActionSendPwm::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionSendPwm::execute(const TestRepetitions& testrepetition)
 {
     if(!profile_.empty())
     {

--- a/src/actionSendPwm.h
+++ b/src/actionSendPwm.h
@@ -21,7 +21,7 @@ class ActionSendPwm : public ActionYarp
 {
     public:
         ActionSendPwm(const CommandAttributes& commandAttributes,const std::string& testCode);    
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
     
     private:

--- a/src/actionSendPwmTrain.cpp
+++ b/src/actionSendPwmTrain.cpp
@@ -46,7 +46,7 @@ void ActionSendPwmTrain::beforeExecute()
     getCommandAttribute("wrappername",wrapperPrefix_);        
 }
 
-execution ActionSendPwmTrain::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionSendPwmTrain::execute(const TestRepetitions& testrepetition)
 {
 
     yarp::dev::IPWMControl *ipwm=nullptr;

--- a/src/actionSendPwmTrain.h
+++ b/src/actionSendPwmTrain.h
@@ -29,7 +29,7 @@ class ActionSendPwmTrain : public ActionYarp
 {
     public:
         ActionSendPwmTrain(const CommandAttributes& commandAttributes,const std::string& testCode);    
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;
                 
     private:

--- a/src/actionYarpNow.cpp
+++ b/src/actionYarpNow.cpp
@@ -25,7 +25,7 @@ void ActionYarpNow::beforeExecute()
 {
 }
 
-execution ActionYarpNow::execute(const TestRepetitions&)
+BlockTestCore::execution ActionYarpNow::execute(const TestRepetitions&)
 {
     return BlockTestCore::execution::continueexecution;;
 }

--- a/src/actionYarpNow.h
+++ b/src/actionYarpNow.h
@@ -25,7 +25,7 @@ class ActionYarpNow : public ActionYarp
 {
     public:
         ActionYarpNow(const CommandAttributes& commandAttributes,const std::string& testCode);    
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
         double getDouble() override;    
     private:        

--- a/src/actionYarpWait.cpp
+++ b/src/actionYarpWait.cpp
@@ -27,7 +27,7 @@ void ActionYarpWait::beforeExecute()
     getCommandAttribute("seconds", seconds_);
 }
 
-execution ActionYarpWait::execute(const TestRepetitions&)
+BlockTestCore::execution ActionYarpWait::execute(const TestRepetitions&)
 {
     //yarp::os::yarpClockType clockType=yarp::os::Time::getClockType();
     //TXLOG(Severity::debug)<<"Using clock type config:"<<yarp::os::Time::clockTypeToString(clockType)<<" Wait value:"<<seconds_<<std::endl;

--- a/src/actionYarpWait.h
+++ b/src/actionYarpWait.h
@@ -25,7 +25,7 @@ class ActionYarpWait : public ActionYarp
 {
     public:
         ActionYarpWait(const CommandAttributes& commandAttributes,const std::string& testCode);    
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
 
     private:        

--- a/src/unusedactions/actionGenerateTrajectory.cpp
+++ b/src/unusedactions/actionGenerateTrajectory.cpp
@@ -32,7 +32,7 @@ void ActionGenerateTrajectory::beforeExecute()
 }
 
 
-execution ActionGenerateTrajectory::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionGenerateTrajectory::execute(const TestRepetitions& testrepetition)
 {
     yarp::os::Port rpcPortWalking;
     WalkingCommands walkingCommands;

--- a/src/unusedactions/actionGenerateTrajectory.h
+++ b/src/unusedactions/actionGenerateTrajectory.h
@@ -20,7 +20,7 @@ class ActionGenerateTrajectory : public ActionYarp
 {
     public:
         ActionGenerateTrajectory(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
     private:
         double lenght_{0};

--- a/src/unusedactions/actionPrepareStraightWalking.cpp
+++ b/src/unusedactions/actionPrepareStraightWalking.cpp
@@ -25,7 +25,7 @@ void ActionPrepareStraightWalking::beforeExecute()
 {
 }
 
-execution ActionPrepareStraightWalking::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionPrepareStraightWalking::execute(const TestRepetitions& testrepetition)
 {
     yarp::os::Port rpcPortWalking;
     WalkingCommands walkingCommands;

--- a/src/unusedactions/actionPrepareStraightWalking.h
+++ b/src/unusedactions/actionPrepareStraightWalking.h
@@ -25,7 +25,7 @@ class ActionPrepareStraightWalking : public ActionYarp
 {
     public:
         ActionPrepareStraightWalking(const CommandAttributes& commandAttributes,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
 
     ACTIONREGISTER_DEC_TYPE(ActionPrepareStraightWalking)        

--- a/src/unusedactions/actionResetWalking.cpp
+++ b/src/unusedactions/actionResetWalking.cpp
@@ -32,7 +32,7 @@ void ActionResetWalking::beforeExecute()
 {
 }
 
-execution ActionResetWalking::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionResetWalking::execute(const TestRepetitions& testrepetition)
 {
     yarp::os::Port rpcPortWalking;
     WalkingCommands walkingCommands;

--- a/src/unusedactions/actionResetWalking.h
+++ b/src/unusedactions/actionResetWalking.h
@@ -26,7 +26,7 @@ class ActionResetWalking : public ActionYarp
 {
     public:
         ActionResetWalking(const CommandAttributes& commandAttributes,,const std::string& testCode);
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
 
     ACTIONREGISTER_DEC_TYPE(ActionResetWalking)        

--- a/src/unusedactions/actionSetVelocity.cpp
+++ b/src/unusedactions/actionSetVelocity.cpp
@@ -31,7 +31,7 @@ void ActionSetVelocity::beforeExecute()
     getCommandAttribute("yvelocity",yVelocity_);          
 }
 
-execution ActionSetVelocity::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionSetVelocity::execute(const TestRepetitions& testrepetition)
 {
     yarp::os::Port rpcPortWalking;
     WalkingCommands walkingCommands;

--- a/src/unusedactions/actionSetVelocity.h
+++ b/src/unusedactions/actionSetVelocity.h
@@ -29,7 +29,7 @@ class ActionSetVelocity : public ActionYarp
 
     public:
         ActionSetVelocity(const CommandAttributes& commandAttributes,const std::string& testCode);    
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
 
     ACTIONREGISTER_DEC_TYPE(ActionSetVelocity)        

--- a/src/unusedactions/actionStartWalking.cpp
+++ b/src/unusedactions/actionStartWalking.cpp
@@ -28,7 +28,7 @@ void ActionStartWalking::beforeExecute()
 {
 }
 
-execution ActionStartWalking::execute(const TestRepetitions& testrepetition)
+BlockTestCore::execution ActionStartWalking::execute(const TestRepetitions& testrepetition)
 {
     yarp::os::Port rpcPortWalking;
     WalkingCommands walkingCommands;

--- a/src/unusedactions/actionStartWalking.h
+++ b/src/unusedactions/actionStartWalking.h
@@ -26,7 +26,7 @@ class ActionStartWalking : public ActionYarp
 {
     public:
         ActionStartWalking(const CommandAttributes& commandAttributes,const std::string& testCode);        
-        execution execute(const TestRepetitions& testrepetition) override;
+        BlockTestCore::execution execute(const TestRepetitions& testrepetition) override;
         void beforeExecute() override;        
 
     ACTIONREGISTER_DEC_TYPE(ActionStartWalking)        


### PR DESCRIPTION
https://github.com/robotology/blocktest-yarp-plugins/pull/16 was incomplete.